### PR TITLE
Verbose nested namespace syntax (not C++17)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -4,6 +4,7 @@ Changelog
 - Bugfix: Fixed byte order in image format string used for Pillow
 - Bugfix: Prevent segmentation fault when performing some operations on locked documents (fixes #4)
 - Bugfix: Fix include paths in C++ (fixes #2)
+- Change namespace syntax to support old compilers (earlier than C++17) (fixes #6)
 
 0.2.0
 - Add the font infos to the TextBox object (Poppler 0.89.0)

--- a/src/cpp/version.cpp
+++ b/src/cpp/version.cpp
@@ -19,8 +19,11 @@
 #include <pybind11/pybind11.h>
 #include <poppler-version.h>
 
-namespace poppler::version
+namespace poppler
 {
+namespace version
+{
+
 
 PYBIND11_MODULE(version, m)
 {
@@ -30,4 +33,5 @@ PYBIND11_MODULE(version, m)
     m.def("version_micro", &version_micro);
 }
 
-} // namespace poppler::version
+} // namespace version
+} // namespace poppler


### PR DESCRIPTION
This more verbose syntax does not require C++17 syntax and works with older compilers.

Resolves: #6