### PR TITLE
Fix corrupted document buffer

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,5 +1,8 @@
 Changelog
 
+0.2.2
+- Bugfix: Document can be corrupted by garbage collector when created from data (or from file handle) (fixes #19)
+
 0.2.1
 - Bugfix: Fixed byte order in image format string used for Pillow
 - Bugfix: Prevent segmentation fault when performing some operations on locked documents (fixes #4)

--- a/src/poppler/document.py
+++ b/src/poppler/document.py
@@ -53,8 +53,9 @@ class Document:
     PageLayout = document.page_layout_enum
     PageMode = document.page_mode_enum
 
-    def __init__(self, poppler_document):
+    def __init__(self, poppler_document, data=None):
         self._document = poppler_document
+        self._data = data
 
     @ensure_unlocked
     def create_font_iterator(self, page=0):
@@ -282,7 +283,8 @@ def load_from_file(file_name, owner_password=None, user_password=None):
 
 def load_from_data(file_data: bytes, owner_password=None, user_password=None):
     return Document(
-        document.load_from_data(file_data, owner_password or "", user_password or "")
+        document.load_from_data(file_data, owner_password or "", user_password or ""),
+        file_data
     )
 
 


### PR DESCRIPTION
Fixes #19 

poppler load_from_data takes a pointer to data as argument. I am creating this pointer from a bytes object. However, the poppler document do not copy the buffer data, and uses it for different operations. The python bytes object was garbage collected, and the poppler document tried to access its data from a no longer valid pointer.

The solution is to keep the bytes object as member of the python document object, to keep it alive as long as the document is alive.