### PR TITLE
Adding EmbeddedFile.checksum_bytes and EmbeddedFile.data_bytes

### DIFF
--- a/src/cpp/embedded_file.cpp
+++ b/src/cpp/embedded_file.cpp
@@ -29,8 +29,16 @@ PYBIND11_MODULE(embedded_file, m)
 {
     py::class_<embedded_file>(m, "embedded_file")
         .def("checksum", &embedded_file::checksum)
+        .def("checksum_bytes", [](const embedded_file &self){
+            auto &&data = self.checksum();
+            return py::bytes(&data[0], data.size());
+        })
         .def("creation_date", &embedded_file::creation_date)
         .def("data", &embedded_file::data)
+        .def("data_bytes", [](const embedded_file &self){
+            auto &&data = self.data();
+            return py::bytes(&data[0], data.size());
+        })
         .def("description", &embedded_file::description)
         .def("is_valid", &embedded_file::is_valid)
         .def("mime_type", &embedded_file::mime_type)

--- a/src/poppler/embeddedfile.py
+++ b/src/poppler/embeddedfile.py
@@ -27,12 +27,20 @@ class EmbeddedFile:
         return self._file.checksum()
 
     @property
+    def checksum_bytes(self):
+        return self._file.checksum_bytes()
+
+    @property
     def creation_date(self):
         return from_time_type(self._file.creation_date())
 
     @property
     def data(self):
         return self._file.data()
+
+    @property
+    def data_bytes(self):
+        return self._file.data_bytes()
 
     @property
     def description(self):


### PR DESCRIPTION
These return EmbeddedFile.checksum and EmbeddedFile.data in Python `bytes`, respectively. These functions formerly returned a list of strings, which made the binary data really difficult to handle.