### PR TITLE
Make _ position consistent in Rotation Enum

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ Next release
 - EmbeddedFile data() and checksum() now return bytes (See :pr:`32`) -- by Bence Cs
 - Bugfix: Fixed typos in EmbeddedFile.modification_date and EmbeddedFile.is_valid
 - Bugfix: Fixed typo in page.search (Fixes :issue:`37`)  -- by Bohumír Zámečník
+- Bugfix: Fix underscore position in two attributes of the Rotation Enum, thereby
+  making it consistent with the upstream ``poppler-cpp`` (:issue:`42` / :pr:`44`) -- by mara004
 
 0.2.2 (2020-10-03)
 ------------------

--- a/src/cpp/global.cpp
+++ b/src/cpp/global.cpp
@@ -68,8 +68,8 @@ PYBIND11_MODULE(global_, m)
     py::enum_<rotation_enum>(m, "rotation_enum")
         .value("rotate_0", rotation_enum::rotate_0)
         .value("rotate_90", rotation_enum::rotate_90)
-        .value("rotate18_0", rotation_enum::rotate_180)
-        .value("rotate27_0", rotation_enum::rotate_270)
+        .value("rotate_180", rotation_enum::rotate_180)
+        .value("rotate_270", rotation_enum::rotate_270)
         .export_values();
 
     py::class_<ustring>(m, "_ustring")


### PR DESCRIPTION
This MR fixes issue #42.

The Rotation Enum did not match the upstream `poppler-cpp`.
The position of the underscore for two attributes was very unexpected and probably inadvertent.
This change is *somewhat* API-breaking and needs additional clarification in the docs.