### PR TITLE
Add binding for error functions and poppler.enable_logging().

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -242,3 +242,16 @@ If you modify the array, image data will be automatically modified as well.
 .. Converting to OpenCV image
 .. ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Suppressing error messages
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For some documents Poppler may produce a lot of error messages, by default sent
+to the stderr. If this is not desirable it's possible to disable them altogether.
+
+.. code-block:: python
+
+  # disable logging
+  poppler.enable_logging(False)
+
+  # enable logging to stderr again
+  poppler.enable_logging(True)

--- a/src/cpp/global.cpp
+++ b/src/cpp/global.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "version.h"
+#include <iostream>
 #include <pybind11/pybind11.h>
 #include <poppler-global.h>
 #include <algorithm>
@@ -38,6 +39,24 @@ poppler::ustring to_ustring(std::string str)
 {
     return poppler::ustring::from_utf8(str.data(), str.size());
 }
+
+#if HAS_VERSION(0, 30)
+void stderr_debug_function(const std::string &msg, void * /*data*/)
+{
+    std::cerr << "poppler/" << msg << std::endl;
+}
+
+void noop_debug_function(const std::string &, void *) { }
+
+void enable_logging(const bool verbose)
+{
+    if (verbose) {
+        poppler::set_debug_error_function(stderr_debug_function, nullptr);
+    } else{
+        poppler::set_debug_error_function(noop_debug_function, nullptr);
+    }
+}
+#endif
 
 PYBIND11_MODULE(global_, m)
 {
@@ -79,6 +98,10 @@ PYBIND11_MODULE(global_, m)
 
 #if HAS_VERSION(0, 73)
     m.def("set_data_dir", &set_data_dir, py::arg("new_data_dir"));
+#endif
+
+#if HAS_VERSION(0, 30)
+    m.def("enable_logging", &enable_logging);
 #endif
 }
 

--- a/src/poppler/__init__.py
+++ b/src/poppler/__init__.py
@@ -71,6 +71,11 @@ __all__ = [
     "TransitionType",
 ]
 
+if version() >= (0, 30, 0):
+    from poppler.cpp.global_ import enable_logging  # noqa
+
+    __all__.append("enable_logging")
+
 if version() >= (0, 65, 0):
     from poppler.cpp.page_renderer import line_mode_enum as LineMode  # noqa
 


### PR DESCRIPTION
Resolved issue #49. Suppressing error messages

So that we can disable/enable logging to stderr.

Intended usage:
```
# disable logging
poppler.enable_logging(False)

# enable logging to stderr again
poppler.enable_logging(True)
```

Passing the function pointer is wrapped inside the C++ code since it may
be more difficult to pass a python function as C++ function pointer.
Also the user-facing API is thus a bit simpler.

---

It would be nicer to have some more pythonic way to control the logging. If needed one can imagine passing a custom error function which would log the error message into a standard python logger.

---

TODO: I'd like to find some sample PDF with errors being output + a unit test.
