### PR TITLE
Define ssize_t for Windows

### DIFF
--- a/src/cpp/document.cpp
+++ b/src/cpp/document.cpp
@@ -28,6 +28,11 @@
 #include <poppler-page.h>
 #include <poppler-toc.h>
 
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 namespace py = pybind11;
 
 namespace poppler


### PR DESCRIPTION
This PR defines ```ssize_t``` in [document.cpp](https://github.com/cbrunet/python-poppler/blob/master/src/cpp/document.cpp) so that it can be compiled on Windows.

I know that Windows is currently not supported, but following [this reply](https://github.com/cbrunet/python-poppler/issues/9#issuecomment-863202633) only works for me if ```ssize_t``` is defined, as it seems to be a unique POSIX type. Perhaps you want to keep this PR around until Windows is supported in order to not pollute the code with Windows-specific code now, but it could be useful for people wanting to go through some hoops in order to use the library on Windows.