### PR TITLE
Fix: add pure: false to meson.build (#74).

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project(
 poppler_dep = dependency('poppler-cpp', version: '>=0.26.0')
 
 python_mod = import('python')
-python3 = python_mod.find_installation('python3')
+python3 = python_mod.find_installation('python3', pure: false)
 
 pybind11_proj = subproject('pybind11')
 pybind11_dep = pybind11_proj.get_variable('pybind11_dep')


### PR DESCRIPTION
Since meson-python-0.13.0 it's required for non-pure builds.