### PR TITLE
Fix: Remove image.copy() argument in poppler 25.01

### DIFF
--- a/src/cpp/image.cpp
+++ b/src/cpp/image.cpp
@@ -102,7 +102,11 @@ PYBIND11_MODULE(image, m)
         .def(py::init<int, int, image::format_enum>(), py::arg("iwidth"), py::arg("iheight"), py::arg("iformat"))
         .def("bytes_per_row", &image::bytes_per_row)
         // .def("const_data", &image::const_data)
+#if HAS_VERSION(25, 1)
+        .def("copy", &image::copy)
+#else
         .def("copy", &image::copy, py::arg("rect") = rect())
+#endif
         .def("data", &data)
         .def("set_data", &set_data)
         .def("format", &image::format)

--- a/src/poppler/image.py
+++ b/src/poppler/image.py
@@ -16,7 +16,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from poppler.cpp import image
-from poppler.rectangle import Rectangle
 
 
 class Image:
@@ -47,8 +46,8 @@ class Image:
     def const_data(self):
         return self._image.data()
 
-    def copy(self, rect=None):
-        image = self._image.copy(rect or Rectangle()._rect)
+    def copy(self):
+        image = self._image.copy()
         return Image.from_object(image)
 
     @property


### PR DESCRIPTION
Building the wheel started failing after upgrade to poppler 25.01.

```
      ../src/cpp/image.cpp:105:10: note: in instantiation of function template specialization 'pybind11::class_<poppler::image>::def<poppler::image (poppler::image::*)() const, pybind11::arg_v>' requested here
        105 |         .def("copy", &image::copy, py::arg("rect") = rect())
            |          ^
      1 warning and 1 error generated.
```

From poppler changelog: "Remove rect parameter from image::copy, it was never implemented".

In `src/cpp/image.cpp` the `image.copy()` function should be now declared as:
```
.def("copy", &image::copy)
```
instead of:
```
.def("copy", &image::copy, py::arg("rect") = rect())
```

i.e. using the HAS_VERISON (fixed like this in the PR):
```
#if HAS_VERSION(25, 1)
        .def("copy", &image::copy)
#else
        .def("copy", &image::copy, py::arg("rect") = rect())
#endif
```

It might be also good to upgrade ubuntu/poppler in `.github/workflows/build_and_test.yml`.